### PR TITLE
add built in conditional compilation support

### DIFF
--- a/parsing/lexer.mli
+++ b/parsing/lexer.mli
@@ -16,6 +16,18 @@ val init : unit -> unit
 val token: Lexing.lexbuf -> Parser.token
 val skip_sharp_bang: Lexing.lexbuf -> unit
 
+type directive_type = 
+  | Dir_type_bool 
+  | Dir_type_float 
+  | Dir_type_int 
+  | Dir_type_string 
+
+type directive_value =
+  | Dir_bool of bool 
+  | Dir_float of float
+  | Dir_int of int
+  | Dir_string of string
+
 type error =
   | Illegal_character of char
   | Illegal_escape of string
@@ -24,6 +36,13 @@ type error =
   | Unterminated_string_in_comment of Location.t * Location.t
   | Keyword_as_label of string
   | Literal_overflow of string
+  | Unterminated_paren_in_conditional
+  | Unterminated_if
+  | Unterminated_else 
+  | Unexpected_token_in_conditional 
+  | Expect_hash_then_in_conditional
+  | Unexpected_directive
+  | Conditional_expr_expected_type of directive_type * directive_type
 ;;
 
 exception Error of error * Location.t
@@ -56,3 +75,14 @@ val set_preprocessor :
   (unit -> unit) ->
   ((Lexing.lexbuf -> Parser.token) -> Lexing.lexbuf -> Parser.token) ->
   unit
+
+
+val replace_directive_built_in_value : 
+  string ->  directive_value -> unit
+
+(** Raises Not_found *)
+val find_directive_built_in_value :
+  string -> directive_value
+
+val semantic_version_parse :
+  string -> int * int * int * string


### PR DESCRIPTION
# Syntax

```ocaml
#if predicate #then
    ...
#else
   ...
#end
```
```
predicate
| predicate && predicate
| predicate || predicate
| atom RL atom

atom
| string
| identifier
| int
| float
RL
| "==" | "<>" | "<=" | ">=" | "<" | ">"

````
it is type safe, there is no type conversion
## design
we restrict `#if`, `#else`, `#end` to be in the beginning of a line, 
it is not really necessary(a strict syntax makes tooling easier, and seems faster when having lots of `#`, true in bucklescript)

# Internal implementation tradeoff

1. change the tokenizer add `HASH_IF`, `HASH_ELSE` etc
   cons: 
   1. changed the interface of `Parse.token`, may break other libs like ppx_optcomp
   2. there is no clean way to differentiate `#if` and `#if_` we need a char look ahead, 
       doable though

2. look-ahead one token.
   cons:
   1. slightly slower