### PR TITLE
Try a hack encoding of extra information without changing the type of…

### DIFF
--- a/bytecomp/lambda.ml
+++ b/bytecomp/lambda.ml
@@ -34,7 +34,7 @@ type tag_info =
   | Blk_array
   | Blk_variant of string 
   | Blk_record of string array (* when its empty means we dont get such information *)
-  | Blk_module of string list option
+  | Blk_module of string list
   | Blk_extension_slot
   | Blk_na
   | Blk_some

--- a/bytecomp/lambda.mli
+++ b/bytecomp/lambda.mli
@@ -36,7 +36,7 @@ type tag_info =
   | Blk_array
   | Blk_variant of string 
   | Blk_record of string array
-  | Blk_module of string list option
+  | Blk_module of string list
   | Blk_extension_slot
   | Blk_na
   | Blk_some

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -89,14 +89,17 @@ let rec apply_coercion loc strict restr arg =
     Tcoerce_none ->
       arg
   | Tcoerce_structure(runtime_fields, pos_cc_list, id_pos_list) ->
-
+      let names = Array.of_list runtime_fields in
       name_lambda strict arg (fun id ->
-        let get_field pos = Lprim(Pfield (pos, Fld_na (*TODO*)),[Lvar id], loc) in
+        let get_field_i i pos =
+          Lprim(Pfield (pos, Fld_module names.(i)),[Lvar id], loc) in
+        let get_field_name name pos =
+          Lprim(Pfield (pos, Fld_module name),[Lvar id], loc) in
         let lam =
           Lprim(Pmakeblock(0, Blk_module (Some runtime_fields), Immutable),
-                List.map (apply_coercion_field loc get_field) pos_cc_list, loc)
+                List.mapi (fun i x -> (apply_coercion_field loc (get_field_i i) x)) pos_cc_list, loc)
         in
-        wrap_id_pos_list loc id_pos_list get_field lam)
+        wrap_id_pos_list loc id_pos_list get_field_name lam)
   | Tcoerce_functor(cc_arg, cc_res) ->
       let param = Ident.create "funarg" in
       name_lambda strict arg (fun id ->
@@ -123,7 +126,7 @@ and wrap_id_pos_list loc id_pos_list get_field lam =
       if IdentSet.mem id' fv then
         let id'' = Ident.create (Ident.name id') in
         (Llet(Alias,id'',
-              apply_coercion loc Alias c (get_field pos),lam),
+              apply_coercion loc Alias c (get_field (Ident.name id') pos),lam),
          Ident.add id' (Lvar id'') s)
       else (lam,s))
       (lam, Ident.empty) id_pos_list
@@ -421,6 +424,7 @@ and transl_structure loc fields cc rootpath = function
           let v = Array.of_list (List.rev fields) in
           let get_field pos = Lvar v.(pos)
           and ids = List.fold_right IdentSet.add fields IdentSet.empty in
+          let get_field_name _name = get_field in
           let result = List.fold_right
               (fun  (pos, cc) code ->
                  begin match cc with
@@ -440,7 +444,7 @@ and transl_structure loc fields cc rootpath = function
           and id_pos_list =
             List.filter (fun (id,_,_) -> not (IdentSet.mem id ids)) id_pos_list
           in
-          wrap_id_pos_list loc id_pos_list get_field lam
+          wrap_id_pos_list loc id_pos_list get_field_name lam
       | _ ->
           fatal_error "Translmod.transl_structure"
       end

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -497,7 +497,7 @@ and transl_structure loc fields cc rootpath = function
         [] ->
           transl_structure loc newfields cc rootpath rem
       | id :: ids ->
-          Llet(Alias, id, Lprim(Pfield (pos, Fld_na), [Lvar mid], incl.incl_loc),
+          Llet(Alias, id, Lprim(Pfield (pos, Fld_module (Ident.name id)), [Lvar mid], incl.incl_loc),
                rebind_idents (pos + 1) (id :: newfields) ids) in
       Llet(pure_module modl, mid, transl_module Tcoerce_none None modl,
            rebind_idents 0 fields ids)

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -88,11 +88,11 @@ let rec apply_coercion loc strict restr arg =
   match restr with
     Tcoerce_none ->
       arg
-  | Tcoerce_alias (path, Tcoerce_structure(runtime_fields, pos_cc_list, id_pos_list))
+  | Tcoerce_alias (path, Tcoerce_structure(_runtime_fields, pos_cc_list, id_pos_list))
     when Includemod.is_hack_for_alias path ->
-      let extracted = Includemod.extract_hack_for_alias path in
-      assert (runtime_fields |> String.concat("$") = extracted);
-      (* Printf.eprintf "\n\nXXX encoding hack for coerce_structure found:%s\n\n" extracted; *)
+      let runtime_fields = Includemod.extract_hack_for_alias path in
+      (* Printf.eprintf "\n\nXXX encoding hack for coerce_structure found:%s\n\n" (runtime_fields |> String.concat ","); *)
+      assert (runtime_fields = _runtime_fields);
       let names = Array.of_list runtime_fields in
       name_lambda strict arg (fun id ->
         let get_field_i i pos =
@@ -426,7 +426,7 @@ and transl_structure loc fields cc rootpath = function
                          export_identifiers :=  id :: !export_identifiers);
                       (Lvar id :: acc) end) fields [] , loc
                  )
-      | Tcoerce_alias (path, Tcoerce_structure(runtime_fields, pos_cc_list, id_pos_list))
+      | Tcoerce_alias (path, Tcoerce_structure(_runtime_fields, pos_cc_list, id_pos_list))
         when Includemod.is_hack_for_alias path ->
               (* Do not ignore id_pos_list ! *)
           (*Format.eprintf "%a@.@[" Includemod.print_coercion cc;
@@ -434,9 +434,9 @@ and transl_structure loc fields cc rootpath = function
             fields;
           Format.eprintf "@]@.";*)
 
-          let extracted = Includemod.extract_hack_for_alias path in
-          assert (runtime_fields |> String.concat("$") = extracted);
-          (* Printf.eprintf "\n\nXXX encoding hack for coerce_structure found:%s\n\n" extracted;     *)
+          let runtime_fields = Includemod.extract_hack_for_alias path in
+          (* Printf.eprintf "\n\nXXX encoding hack for coerce_structure found:%s\n\n" (runtime_fields |> String.concat ","); *)
+          assert (runtime_fields = _runtime_fields);         
           
           let v = Array.of_list (List.rev fields) in
           let get_field pos = Lvar v.(pos)

--- a/bytecomp/translmod.ml
+++ b/bytecomp/translmod.ml
@@ -92,7 +92,7 @@ let rec apply_coercion loc strict restr arg =
     when Includemod.is_hack_for_alias path ->
       let extracted = Includemod.extract_hack_for_alias path in
       assert (runtime_fields |> String.concat("$") = extracted);
-      Printf.eprintf "\n\nXXX encoding hack for coerce_structure found:%s\n\n" extracted;
+      (* Printf.eprintf "\n\nXXX encoding hack for coerce_structure found:%s\n\n" extracted; *)
       let names = Array.of_list runtime_fields in
       name_lambda strict arg (fun id ->
         let get_field_i i pos =
@@ -436,7 +436,7 @@ and transl_structure loc fields cc rootpath = function
 
           let extracted = Includemod.extract_hack_for_alias path in
           assert (runtime_fields |> String.concat("$") = extracted);
-          Printf.eprintf "\n\nXXX encoding hack for coerce_structure found:%s\n\n" extracted;    
+          (* Printf.eprintf "\n\nXXX encoding hack for coerce_structure found:%s\n\n" extracted;     *)
           
           let v = Array.of_list (List.rev fields) in
           let get_field pos = Lvar v.(pos)

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -197,15 +197,25 @@ let hack_id_for_alias = (* lazy to avoid changing the id counter *)
 let is_hack_id_for_alias id = id == Lazy.force hack_id_for_alias
 
 let create_hack_for_alias runtime_fields =
-  Path.Pdot (Path.Pident (Lazy.force hack_id_for_alias), (runtime_fields |> String.concat "$"), 0)
+  Path.Pdot (Path.Pident (Lazy.force hack_id_for_alias), (runtime_fields |> String.concat ","), 0)
 
 let is_hack_for_alias path = match path with
   | Path.Pdot (Path.Pident id, _, _) -> is_hack_id_for_alias id
   | _ -> false
 
+let rec split_from s n = match String.index_from s n ',' with
+  | pos -> String.sub s n (pos-n) :: split_from s (pos+1)
+  | exception Not_found ->
+    let len = String.length s - n in
+    if len = 0 then [] else [String.sub s n len]
+
+let split s = split_from s 0
+
 let extract_hack_for_alias path = match path with
-  | Path.Pdot (Path.Pident id, s, _) when is_hack_id_for_alias id -> s
-  | _ -> ""
+  | Path.Pdot (Path.Pident id, s, _) when is_hack_id_for_alias id ->
+    split s
+  | _ ->
+    []
 
 (* Simplify a structure coercion *)
 

--- a/typing/includemod.ml
+++ b/typing/includemod.ml
@@ -171,7 +171,7 @@ let rec print_coercion ppf c =
   let pr fmt = Format.fprintf ppf fmt in
   match c with
     Tcoerce_none -> pr "id"
-  | Tcoerce_structure (_, fl, nl) ->
+  | Tcoerce_structure (fl, nl) ->
       pr "@[<2>struct@ %a@ %a@]"
         (print_list print_coercion2) fl
         (print_list print_coercion3) nl
@@ -229,7 +229,7 @@ let simplify_structure_coercion runtime_fields cc id_pos_list =
   then Tcoerce_none
   else Tcoerce_alias (
         create_hack_for_alias runtime_fields,
-        Tcoerce_structure (runtime_fields, cc, id_pos_list))
+        Tcoerce_structure (cc, id_pos_list))
 
 
 (* Inclusion between module types.
@@ -361,11 +361,9 @@ and signatures env cxt subst sig1 sig2 =
               if len1 = len2 then (* see PR#5098 *)
                 simplify_structure_coercion runtime_fields cc id_pos_list
               else
-              if true (* !Clflags.bs_only *) then
                 Tcoerce_alias(
                   create_hack_for_alias runtime_fields,
-                  Tcoerce_structure (runtime_fields, cc, id_pos_list))
-              else Tcoerce_structure (runtime_fields, cc, id_pos_list)
+                  Tcoerce_structure (cc, id_pos_list))
           | _  -> raise(Error unpaired)
         end
     | item2 :: rem ->

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -56,4 +56,3 @@ val expand_module_alias: Env.t -> pos list -> Path.t -> Types.module_type
 
 val is_hack_for_alias: Path.t -> bool
 val extract_hack_for_alias: Path.t -> string
-val compose_hacks_for_alias : Path.t -> Path.t -> Path.t

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -55,4 +55,4 @@ val report_error: formatter -> error list -> unit
 val expand_module_alias: Env.t -> pos list -> Path.t -> Types.module_type
 
 val is_hack_for_alias: Path.t -> bool
-val extract_hack_for_alias: Path.t -> string
+val extract_hack_for_alias: Path.t -> string list

--- a/typing/includemod.mli
+++ b/typing/includemod.mli
@@ -53,3 +53,7 @@ exception Error of error list
 
 val report_error: formatter -> error list -> unit
 val expand_module_alias: Env.t -> pos list -> Path.t -> Types.module_type
+
+val is_hack_for_alias: Path.t -> bool
+val extract_hack_for_alias: Path.t -> string
+val compose_hacks_for_alias : Path.t -> Path.t -> Path.t

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -241,7 +241,7 @@ and value_binding =
 
 and module_coercion =
     Tcoerce_none
-  | Tcoerce_structure of string list * (* runtime fields *)
+  | Tcoerce_structure of
                         (int * module_coercion) list *
                         (Ident.t * int * module_coercion) list
   | Tcoerce_functor of module_coercion * module_coercion

--- a/typing/typedtree.ml
+++ b/typing/typedtree.ml
@@ -241,8 +241,9 @@ and value_binding =
 
 and module_coercion =
     Tcoerce_none
-  | Tcoerce_structure of (int * module_coercion) list *
-                         (Ident.t * int * module_coercion) list
+  | Tcoerce_structure of string list * (* runtime fields *)
+                        (int * module_coercion) list *
+                        (Ident.t * int * module_coercion) list
   | Tcoerce_functor of module_coercion * module_coercion
   | Tcoerce_primitive of Ident.t *  Primitive.description
   | Tcoerce_alias of Path.t * module_coercion

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -240,7 +240,7 @@ and value_binding =
 
 and module_coercion =
     Tcoerce_none
-  | Tcoerce_structure of string list * (* runtime fields *)
+  | Tcoerce_structure of
                          (int * module_coercion) list *
                          (Ident.t * int * module_coercion) list
   | Tcoerce_functor of module_coercion * module_coercion

--- a/typing/typedtree.mli
+++ b/typing/typedtree.mli
@@ -240,7 +240,8 @@ and value_binding =
 
 and module_coercion =
     Tcoerce_none
-  | Tcoerce_structure of (int * module_coercion) list *
+  | Tcoerce_structure of string list * (* runtime fields *)
+                         (int * module_coercion) list *
                          (Ident.t * int * module_coercion) list
   | Tcoerce_functor of module_coercion * module_coercion
   | Tcoerce_primitive of Ident.t * Primitive.description


### PR DESCRIPTION
… module_coercion.

Instead of extending Tcoerce_structure with runtime fields, try to encode the same information by wrapping in an additional dummy layer of Tcoerce_alias.