### PR TITLE
Add package.json for `esy`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "ocaml",
+  "version": "4.02.3000+BS",
+  "description": "BuckleScript's OCaml Compiler as an npm Package",
+  "esy": {
+    "build": [
+      "./configure -no-cfi -prefix $cur__install",
+      "make -j world.opt"
+    ],
+    "install": [
+      "make install"
+    ],
+    "buildsInSource": true,
+    "exportedEnv": {
+      "OCAMLLIB": {
+        "val": "#{self.lib / 'ocaml' }",
+        "scope": "global"
+      },
+      "CAML_LD_LIBRARY_PATH": {
+        "val": "#{self.lib / 'ocaml'  / 'stublibs' : self.lib / 'ocaml'  : $CAML_LD_LIBRARY_PATH}",
+        "scope": "global"
+      },
+      "OCAML_TOPLEVEL_PATH": {
+        "val": "#{self.lib / 'ocaml' }",
+        "scope": "global"
+      }
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/BuckleScript/ocaml.git"
+  },
+  "keywords": [
+    "ocaml",
+    "flow",
+    "opam"
+  ],
+  "license": "QPL - See LICENSE at https://github.com/ocaml/ocaml"
+}


### PR DESCRIPTION
Adds a package.json so that we can depend on this OCaml version from `esy`. The version scheme is the same as is used in the OCaml versions published by the `esy` team.

I will soon open a PR to `bucklescript` repo that adds a `esy.json` that depends on this OCaml version.